### PR TITLE
Correct the build output path in angular.json and the public director…

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -13,6 +13,7 @@
         "build": {
           "builder": "@angular/build:application",
           "options": {
+            "outputPath": "dist/jornalismo-angular",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"

--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,6 @@
 {
   "hosting": {
-    "public": "src",
+    "public": "dist/jornalismo-angular/browser",
     "ignore": [
       "firebase.json",
       "**/.*",


### PR DESCRIPTION
…y in firebase.json.

This change addresses an error during `firebase deploy` where the command was looking for a directory that did not exist.

- The `outputPath` in `angular.json` is set to `dist/jornalismo-angular` to ensure a consistent build output directory.
- The `public` directory in `firebase.json` is set to `dist/jornalismo-angular/browser`, which is the correct location of the browser application after a production build.

Note: The tests were skipped due to an issue with the test environment (missing Chrome binary). The changes are configuration-only and are unlikely to affect application logic.