### PR TITLE
feat: Add build step to Firebase deployment workflow

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: npm install
+      - run: npm run build
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The Firebase deployment was failing with a "Page Not Found" error because the build step was missing from the GitHub Actions workflow. This resulted in an empty `dist` directory being deployed.

This commit adds the `npm install` and `npm run build` steps to the workflow to ensure that the Angular application is built before being deployed to Firebase Hosting.