### PR TITLE
fix(firebase): Correct public directory for hosting

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,6 @@
 {
   "hosting": {
-    "public": "dist/jornalismo-angular/browser",
+    "public": "dist/jornalismo-angular/browser/browser",
     "ignore": [
       "firebase.json",
       "**/.*",


### PR DESCRIPTION
The application was showing a 'Page Not Found' error because the `public` directory in `firebase.json` was pointing to the wrong location.

The Angular build process with client hydration creates a nested `browser` directory within the specified `outputPath`. This change updates the `public` path in `firebase.json` to point to the correct directory containing the `index.html` file, which is `dist/jornalismo-angular/browser/browser`.