### PR TITLE
feat: Replace Blog with Materiais section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ yarn-error.log
 /libpeerconnection.log
 testem.log
 /typings
+npm_output.log
 
 # System files
 .DS_Store

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -21,8 +21,6 @@ export const routes: Routes = [
      {path: 'projetos', component: Projetos},
      {path: 'projeto-tcc', component: ProjetoTCC},
      {path: 'contato', component: Contato},
-     {path: 'post/:id', component: PostComponent },
-     {path: 'blog', component: BlogComponent},
      {path: 'admin', loadChildren: () => import('./admin/admin-module').then(m => m.AdminModule), canActivate: [authGuard]},
      {path: '**', redirectTo: ''},
 ];

--- a/src/app/header/header.html
+++ b/src/app/header/header.html
@@ -7,14 +7,13 @@
                     <ng-container *ngIf="isHomePage(); else otherPages">
                         <li><a href="#materias" (click)="closeMenu()">Artigos</a></li>
                         <li><a href="#projetos" (click)="closeMenu()">Projetos</a></li>
-                        <li><a routerLink="/blog" (click)="closeMenu()">Blog</a></li>
+                        <li><a routerLink="/materiais" (click)="closeMenu()">Materiais</a></li>
                         <li><a href="#contato" (click)="closeMenu()">Contato</a></li>
                     </ng-container>
                     <ng-template #otherPages>
                         <li><a [routerLink]="'/artigos'" fragment="materias" (click)="closeMenu()">Artigos</a></li>
                         <li><a [routerLink]="'/materiais'" (click)="closeMenu()">Materiais</a></li>
                         <li><a [routerLink]="'/projetos'" fragment="projetos" (click)="closeMenu()">Projetos</a></li>
-                        <li><a routerLink="/blog" (click)="closeMenu()">Blog</a></li>
                         <li><a [routerLink]="'/contato'" fragment="contato" (click)="closeMenu()">Contato</a></li>
                     </ng-template>
                     <!--<li><a href="#midia">Áudio & Vídeo</a></li>

--- a/src/app/home/home.html
+++ b/src/app/home/home.html
@@ -40,26 +40,13 @@
         </div>
  </section>
 
-     <section id="blog-recentes" class="portfolio-section bg-light">
+    <section id="materiais" class="portfolio-section bg-light">
         <div class="container">
-            <h2>Últimas do Blog</h2>
-            <div class="portfolio-grid">
-                
-                <div *ngIf="latestPost" class="portfolio-item">
-                    <h3>{{ latestPost.title }}</h3>
-                    <p class="description">
-                        {{ latestPost.content.substring(0, 200) }}...
-                    </p>
-                    <a [routerLink]="['/post', latestPost.id]" class="btn">Leia Mais</a>
-                </div>
-                <div *ngIf="!latestPost">
-                    <p>Nenhum post no blog ainda.</p>
-                </div>
-                
-            </div>
-            <a routerLink="/blog" class="btn">Ver Todos os Posts</a>
+            <h2>Materiais</h2>
+            <p>Acesse a página de materiais para encontrar e-books, artigos e outros recursos para aprofundar seus conhecimentos.</p>
+            <a routerLink="/materiais" class="btn">Ver Materiais</a>
         </div>
-    </section> 
+    </section>
 
     <section id="contato" class="contact-section">
         <div class="container">


### PR DESCRIPTION
This change replaces the "Blog" section with a new "Materiais" section.

- The "Blog" link in the header has been replaced with a "Materiais" link.
- The "Últimas do Blog" section on the home page has been replaced with a "Materiais" section.
- The `/blog` and `/post/:id` routes have been removed.
- Added `npm_output.log` to `.gitignore`.